### PR TITLE
Add smithay-clipboard to documentation page

### DIFF
--- a/content/pages/about.markdown
+++ b/content/pages/about.markdown
@@ -16,7 +16,7 @@ Wayland utilities:
   to factor-out the redundants parts of writing a client, allowing to focus on the
   particularities of each specific app. 
 - [smithay-clipboard](https://github.com/Smithay/smithay-clipboard) is a utility crate
-  to provide access to the wayland clipboard.
+  to provide access to the wayland clipboard for client applications.
 
 Smithay dependencies:
 

--- a/content/pages/about.markdown
+++ b/content/pages/about.markdown
@@ -15,6 +15,8 @@ Wayland utilities:
   to simplify the writing of wayland clients. In mostly include general functionalities
   to factor-out the redundants parts of writing a client, allowing to focus on the
   particularities of each specific app. 
+- [smithay-clipboard](https://github.com/Smithay/smithay-clipboard) is a utility crate
+  to provide access to the wayland clipboard.
 
 Smithay dependencies:
 

--- a/content/pages/documentation.markdown
+++ b/content/pages/documentation.markdown
@@ -8,4 +8,4 @@ Aditionnaly, the docs for the master branches are automatically built and hosted
 - [Wayland-rs master docs](https://smithay.github.io/wayland-rs/)
 - [Wayland-window master docs](https://smithay.github.io/wayland-window/)
 - [Wayland-kbd master docs](https://smithay.github.io/wayland-kbd/)
-
+- [Smithay-clipboard master docs](https://smithay.github.io/smithay-clipboard/)


### PR DESCRIPTION
Adds the new wayland-clipboard crate to the documentation page